### PR TITLE
Add tenant slug and tests; closes #72

### DIFF
--- a/app/controllers/tenants/items_controller.rb
+++ b/app/controllers/tenants/items_controller.rb
@@ -2,13 +2,15 @@ class Tenants::ItemsController < ApplicationController
   include ItemsHelper
 
   def index
+    @tenant = Tenant.find_by(slug: params[:slug])
+
+    redirect_to root_path if @tenant.nil?
+
     if params[:category_name] == 'Shop All' || params[:category_name].nil?
       @items = Item.active
     else
       @items = Category.find_by(name: params[:category_name]).items
     end
-
-    @tenant = Tenant.find_by(organization: params[:tenant])
     @categories = Category.all
   end
 
@@ -31,6 +33,7 @@ class Tenants::ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:title, :price, :description, :image)
+    params.require(:item).permit(:title, :price, :description, :retired,
+                                 :tenant_id, :repayment_begin, :repayment_rate)
   end
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -2,4 +2,13 @@ class Tenant < ActiveRecord::Base
   has_many :items
   has_many :categories, through: :items
   has_many :user
+
+  before_save :create_slug
+
+  validates :location,     presence: true
+  validates :organization, presence: true
+
+  def create_slug
+    self.slug = organization.parameterize
+  end
 end

--- a/app/views/tenants/items/index.html.erb
+++ b/app/views/tenants/items/index.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <% @tenant.items.each do |item| %>
       <div class="box col-lg-3">
-        <h4 class="item-title"> <%= link_to("#{item.title}", item_path(tenant: @tenant.organization, id: item.id))%></h4>
+        <h4 class="item-title"> <%= link_to("#{item.title}", item_path(tenant: @tenant.slug, id: item.id))%></h4>
         <div class="thumbnail">
           <img src="http://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg">
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     resources :orders
   end
 
-  scope ":tenant", module: "tenants", as: "tenant" do
+  scope ":slug", module: "tenants", as: "tenant" do
     get "/" => "items#index"
     resources :items
   end

--- a/db/migrate/20150213021258_add_slug_to_tenants.rb
+++ b/db/migrate/20150213021258_add_slug_to_tenants.rb
@@ -1,0 +1,5 @@
+class AddSlugToTenants < ActiveRecord::Migration
+  def change
+    add_column :tenants, :slug, :string
+  end
+end

--- a/db/migrate/20150213025747_updated_items.rb
+++ b/db/migrate/20150213025747_updated_items.rb
@@ -1,0 +1,6 @@
+class UpdatedItems < ActiveRecord::Migration
+  def change
+    remove_column :items, :reqpayment_begin
+    add_column :items, :repayment_begin, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150212015057) do
+ActiveRecord::Schema.define(version: 20150213025747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,14 +40,14 @@ ActiveRecord::Schema.define(version: 20150212015057) do
   create_table "items", force: :cascade do |t|
     t.string   "title"
     t.integer  "price"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "description"
-    t.boolean  "retired",          default: false
+    t.boolean  "retired",         default: false
     t.integer  "tenant_id"
     t.date     "requested_by"
-    t.date     "reqpayment_begin"
     t.integer  "repayment_rate"
+    t.date     "repayment_begin"
   end
 
   add_index "items", ["tenant_id"], name: "index_items_on_tenant_id", using: :btree
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20150212015057) do
     t.string   "organization"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.string   "slug"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/integration/guest_user_test.rb
+++ b/test/integration/guest_user_test.rb
@@ -77,19 +77,26 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     non_tenant_category = create(:category, name: "bad cats")
     tenant_category = create(:category, name: "agriculture")
     non_tenant_item = create(:item, categories: [non_tenant_category])
-    tenant = create(:tenant, organization: "bob")
+    tenant = create(:tenant, organization: "bob's")
     tenant_item = create(:item, title: "cats", description: "good",
                          categories: [tenant_category])
     tenant.items << tenant_item
-    visit tenant_path(tenant: tenant.organization)
 
-    assert_equal "/bob", current_path
+    visit tenant_path(slug: tenant.slug)
+
+    assert_equal "/bob-s", current_path
     within first(".item-category") do
       assert page.has_content?(tenant_category.name)
       refute page.has_content?(non_tenant_category.name)
     end
     assert page.has_content?(tenant_item.title)
     refute page.has_content?(non_tenant_item.title)
+  end
+
+  test "will be redirected to home page if tenant does not exist" do
+    visit tenant_path(slug: "made-up-shop")
+
+    assert_equal "/", current_path
   end
 
   test "an unauthorized user can signup" do

--- a/test/models/tenant_test.rb
+++ b/test/models/tenant_test.rb
@@ -1,7 +1,27 @@
 require "test_helper"
 
 class TenantTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "tenant has attributes" do
+    tenant = build(:tenant)
+
+    assert tenant.valid?
+  end
+
+  test "tenant is not valid even without an orgnization" do
+    tenant = build(:tenant, organization: nil)
+
+    assert tenant.invalid?
+  end
+
+  test "tenant is not valid without a location" do
+    tenant = build(:tenant, location: nil)
+
+    assert tenant.invalid?
+  end
+
+  test "tenant slug is generated" do
+    tenant = create(:tenant)
+
+    assert_equal tenant.organization.parameterize, tenant.slug
+  end
 end


### PR DESCRIPTION
This involves general cleanup and organization. Rake db:migrate after this PR is merged.

Changes include:
* Add slug column to the tenant model (for increase clarity and url validation)
* Remove/add misspelled column on item table
* Fixed controllers/tenants/items_controller to reroute unknown/misspelled tenant slug's to root
* Added unit tests for tenant model.

