### PR TITLE
Added test, fixed unintended bugs. closes #96

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
   def choose
+    session[:tenant_id] = nil
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
 
   def create
     if User.find_by(new_email)
+      duplicate_email
     else
       user = User.new(user_params)
       user.tenant_id = session[:tenant_id]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,10 @@ class User < ActiveRecord::Base
     tenant_id.nil?
   end
 
+  def admin?
+    false
+  end
+
   private
 
   def email_checker(email)

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -133,6 +133,5 @@ class CreateAUserTest < ActionDispatch::IntegrationTest
 
     assert_equal new_user_path, current_path
     assert page.has_content?("Account Already Exists")
-   end
-
+  end
 end

--- a/test/integration/user_signup_test.rb
+++ b/test/integration/user_signup_test.rb
@@ -108,4 +108,31 @@ class CreateAUserTest < ActionDispatch::IntegrationTest
     assert_equal root_path, current_path
     assert page.has_content?("Thank you for creating an account.")
   end
+
+  test "a user cannot sign up with a non unique email address" do
+    create(:user)
+
+    visit root_path
+    click_link_or_button "Signup"
+    click_link_or_button "Borrower"
+    fill_in "tenant_signup[location]", with: "location"
+    fill_in "tenant_signup[organization]", with: "organization"
+    click_link_or_button "Create Organization"
+    fill_in "signup[username]", with: "username"
+    fill_in "signup[first_name]", with: "firstname"
+    fill_in "signup[last_name]", with: "lastname"
+    fill_in "signup[street]", with: "street"
+    fill_in "signup[city]", with: "city"
+    fill_in "signup[state]", with: "state"
+    fill_in "signup[zipcode]", with: "zipcode"
+    fill_in "signup[country]", with: "country"
+    fill_in "signup[password]", with: "password"
+    fill_in "signup[password_confirmation]", with: "password"
+    fill_in "signup[email]", with: "test@test.com"
+    click_link_or_button "Create Account"
+
+    assert_equal new_user_path, current_path
+    assert page.has_content?("Account Already Exists")
+   end
+
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -111,4 +111,10 @@ class UserTest < ActiveSupport::TestCase
     assert user.lender?
     refute user.borrower?
   end
+
+  test "it is not an admin" do
+    user = create(:user)
+
+    refute user.admin?
+  end
 end


### PR DESCRIPTION
This is a maintenance PR. 

* Using the session to store tenant id on signup was a GREAT idea. (Because it was mine), but it had some unintended consequences of the tenant_id persisting if signup wasn't complete or if it failed. Now, the session[:tenant_id] will be cleared when the user clicks on Signup.

* I made an error in refactoring. Pulled logic out into a new method, but never actually calling said method. Whoops.  Added a test for this method so it won't happen again.

* Removing the roles and enums made other things fail. Created an admin? method in the user model so our Nav bar would stop freaking out.

* Added a test that covers user#admin? method.