### PR TITLE
Fix tenant slug; closes #130

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <% @projects.each do |project| %>
     <div class="box col-lg-3">
-      <%= link_to("#{project.title}", tenant_project_path(slug: project.tenant.organization, id: project.id))%>
+      <%= link_to("#{project.title}", tenant_project_path(slug: project.tenant.slug, id: project.id))%>
       <div class="thumbnail">
         <img src="http://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg">
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,12 +10,7 @@ Rails.application.routes.draw do
 
   get "/choose", to: "static_pages#choose"
 
-  resource :pending_loan, only: [:show, :create, :destroy, :update]
-  # post "/pending_loans", to: "pending_loans#create"
-  # delete "/pending_loans", to: "pending_loans#destroy"
-  # get "/pending_loan", to: "pending_loans#show"
-  # delete "/pending_loan", to: "pending_loans#delete_pending_loan",
-  #                         as: "delete_pending_loan"
+  resource :pending_loan, except: [:index, :edit]
 
   post "/pending_loans", to: "pending_loans#checkout_pending_loans",
                          as: "checkout_pending_loans"

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -34,7 +34,7 @@ FactoryGirl.define do
 
   factory :tenant do
     location "Shenzhen"
-    sequence(:organization) { |n| "lucy#{n}" }
+    sequence(:organization) { |n| "lucy's ##{n} farm" }
   end
 
   factory :category do

--- a/test/integration/guest_user_test.rb
+++ b/test/integration/guest_user_test.rb
@@ -52,13 +52,11 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     click_link_or_button(project.title)
 
     assert_equal tenant_project_path(
-      slug: project.tenant.organization,
-      id: project.id
-    ), current_path
+      slug: project.tenant.slug,
+      id: project.id), current_path
     assert page.has_content?(project.tenant.organization)
     assert page.has_content?(project.tenant.location)
     assert page.has_content?(project.title)
-    # assert page.has_content?(project.photos.first.url)
     assert page.has_content?(project.description)
     assert page.has_content?(project.price / 100)
     assert page.has_content?(project.categories.first.name)
@@ -76,7 +74,7 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     click_link_or_button(project1.title)
 
     assert_equal tenant_project_path(
-      slug: project1.tenant.organization,
+      slug: project1.tenant.slug,
       id: project1.id
     ), current_path
     refute page.has_content?(project2.tenant.organization)

--- a/test/integration/pending_loans_integration_test.rb
+++ b/test/integration/pending_loans_integration_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class CartIntegrationTest < ActionDispatch::IntegrationTest
+class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   test "a cart starts empty" do
@@ -16,7 +16,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
   test "an unauthorized user can add an project to the cart" do
     tenant = create(:tenant)
     tenant.projects << create(:project)
-    visit "/#{tenant.organization}"
+    visit "/#{tenant.slug}"
 
     within(".row") do
       click_link_or_button("Lend")
@@ -31,7 +31,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     tenant = create(:tenant)
     tenant.projects << create(:project)
 
-    visit "/#{tenant.organization}"
+    visit "/#{tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -65,7 +65,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
   test "a user can delete an project from their cart" do
     project = create(:project)
 
-    visit "/#{project.tenant.organization}"
+    visit "/#{project.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -84,11 +84,11 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     project1 = create(:project)
     project2 = create(:project)
 
-    visit "/#{project1.tenant.organization}"
+    visit "/#{project1.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
-    visit "/#{project2.tenant.organization}"
+    visit "/#{project2.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -104,7 +104,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
   test "an unauthorized user cannot checkout until logged in" do
     project = create(:project)
 
-    visit "/#{project.tenant.organization}"
+    visit "/#{project.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -120,11 +120,11 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     project1 = create(:project)
     project2 = create(:project)
 
-    visit "/#{project1.tenant.organization}"
+    visit "/#{project1.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
-    visit "/#{project2.tenant.organization}"
+    visit "/#{project2.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -141,13 +141,13 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
   test "project titles on cart page are links" do
     project = create(:project)
 
-    visit "/#{project.tenant.organization}"
+    visit "/#{project.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
     click_link_or_button(project.title)
 
-    assert_equal tenant_project_path(slug: project.tenant.organization,
+    assert_equal tenant_project_path(slug: project.tenant.slug,
                                      id: project.id), current_path
   end
 
@@ -158,7 +158,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     tenant = create(:tenant)
     tenant.projects << create(:project)
 
-    visit "/#{tenant.organization}"
+    visit "/#{tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -178,7 +178,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     tenant = create(:tenant)
     tenant.projects << create(:project, price: 5000)
 
-    visit "/#{tenant.organization}"
+    visit "/#{tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -198,7 +198,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     to login or create an account" do
     project = create(:project)
 
-    visit "/#{project.tenant.organization}"
+    visit "/#{project.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -212,7 +212,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     project = create(:project)
     user = create(:user)
 
-    visit "/#{project.tenant.organization}"
+    visit "/#{project.tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end
@@ -235,7 +235,7 @@ class CartIntegrationTest < ActionDispatch::IntegrationTest
     tenant = create(:tenant)
     tenant.projects << create(:project)
 
-    visit "/#{tenant.organization}"
+    visit "/#{tenant.slug}"
     within(".row") do
       click_link_or_button("Lend")
     end


### PR DESCRIPTION
Fixed tests and layouts to ensure that tenant paths make use of the tenant slug (the parameterized version of the org name), rather than the org name itself.

Changes include:
* Update factories to include a organization name with spaces to ensure that parameterization is working.
* Update pending_loans test to include slug rather than organization
* Slight cleanup of routes file 
* Update categories/show page to use slug, rather than org name.