### PR TITLE
Add default loan of $25

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,7 @@ class OrdersController < ApplicationController
 
   def index
     if current_user && current_user.id == params[:user_id].to_i
-      @user = User.find(params[:user_id])
+      @user = User.find(order_params[:user_id])
       render :index
     else
       redirect_to root_path
@@ -10,7 +10,7 @@ class OrdersController < ApplicationController
   end
 
   def show
-    @order = Order.find(params[:id])
+    @order = Order.find(order_params[:id])
     if order_owner_or_admin?
       @order
     else
@@ -34,11 +34,13 @@ class OrdersController < ApplicationController
 
   private
 
+  def order_params
+    params.permit(:id, :user_id)
+  end
+
   def order_owner_or_admin?
     current_user && (current_user.id == @order.user_id || current_user.admin?)
   end
-
-  private
 
   def complete_loan(pending_loans)
     @order = pending_loans.checkout!(session[:user_id])

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,22 +4,30 @@ class Order < ActiveRecord::Base
   has_many :loans, after_add: :calculate_new_order_total
   has_many :projects, through: :loans
   validates :user_id, presence: true
-  before_create :calculate_order_total
+  after_save :calculate_order_total
 
   def self.complete
-    all.select { |order| order.status == 'completed'}
+    all.select { |order| order.status == "completed" }
   end
 
   def self.paid
-    all.select { |order| order.status == 'paid'}
+    all.select { |order| order.status == "paid" }
   end
 
   def self.cancelled
-    all.select { |order| order.status == 'cancelled'}
+    all.select { |order| order.status == "cancelled" }
   end
 
   def self.ordered
-    all.select { |order| order.status == 'ordered'}
+    all.select { |order| order.status == "ordered" }
+  end
+
+  def final_total
+    if loans.present?
+      self.total_cost = loans.map(&:amount).reduce(:+)
+    else
+      self.total_cost = 0
+    end
   end
 
   private

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <% @categories.each do |category| %>
     <div class="box col-lg-3">
-      <h4 class="category-name"> <%= link_to("#{category.name}", category_path(id: category.id))%></h4>
+      <h4 class="category-name"> <%= link_to("#{category.name}", projects_path) %></h4>
       <div class="thumbnail">
         <img src="http://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg">
       </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -4,22 +4,23 @@
 
 <h1><%= "Order #{@order.id}" %></h1>
 <h3><%= "#{@order.user.full_name}"%><br><%= "#{@order.user.email}" %></h3>
-
+<h2>Order Status: <%= @order.status %></h2>
 <div id="history">
-  <table class='table table-bordered'>
+  <table class="table table-bordered">
     <thead>
       <tr>
-        <th data-field='Order Number'> Project </th>
-        <th data-field="Price">Price</th>
-        <th data-field='Order Status'>Order Status</th>
+        <th data-field="project"> Project </th>
+        <th data-field="project-location">Location</th>
+        <th data-field="project-price">Loan Amount</th>
       </tr>
     </thead>
     <% @order.loans.each do |loan| %>
       <tr>
         <td><%= link_to loan.project.title, project_path(loan.project) %></td>
-        <td><%= number_to_currency loan.project.price / 100 %></td>
-        <td><%= @order.status %></td>
+        <td><%= loan.project.tenant.location %></td>
+        <td><%= number_to_currency loan.amount / 100 %></td>
       </tr>
     <% end %>
+    <tr><h2>Order Total: <%= number_to_currency @order.final_total / 100 %></h2><tr>
   </table>
 </div>

--- a/app/views/pending_loans/show.html.erb
+++ b/app/views/pending_loans/show.html.erb
@@ -1,28 +1,28 @@
 <h1>Pending Loans</h1>
 
 <div id="pending_loans">
-  <table class='table table-bordered'>
+  <table class="table table-bordered">
     <thead>
       <tr class="warning">
-        <th data-field='Organization Name'>Organization Name</th>
-        <th data-field='Purpose'>Purpose</th>
-        <th data-field='Amount'>Amount</th>
+        <th data-field="Organization Name">Organization Name</th>
+        <th data-field="Purpose">Purpose</th>
+        <th data-field="Amount">Amount</th>
         <th></th>
       </tr>
     </thead>
     <% if @pending_loans.empty? %>
-      <tr><td colspan='6'>You Have No Pending Loans</td></tr>
+      <tr><td colspan="6">You Have No Pending Loans</td></tr>
     <% else %>
       <% @pending_loans.each do |project, loan_amount| %>
         <tr id=<%= "project_#{project.id}" %>>
           <td><%= project.tenant.organization %></td>
           <td><%= link_to project.title, tenant_project_path(slug: project.tenant.slug, id: project.id) %></td>
-          <td id=<%= "quantity_#{project.id}" %>><%= loan_amount %></td>
+          <td id=<%= "quantity_#{project.id}" %>><%= number_to_currency loan_amount.to_i / 100 %></td>
           <td>
             <%= form_for :pending_loan, url: pending_loan_path do |f| %>
               <input name="_method" type="hidden" value="patch" />
               <%= f.hidden_field :project_id, :value => project.id %>
-              <%= f.submit 'Delete', class: "btn btn-default btn-delete-cart-project" %>
+              <%= f.submit "Delete", class: "btn btn-default btn-delete-cart-project" %>
             <% end %>
           </td>
         </tr>
@@ -40,6 +40,6 @@
 
   <%= form_for :cart, url: pending_loan_path do |f| %>
     <input name="_method" type="hidden" value="delete" />
-    <%= f.submit 'Empty Cart', class: 'btn btn-default' %>
+    <%= f.submit "Empty Cart", class: "btn btn-default" %>
   <% end %>
 </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,11 +5,17 @@
   <div class="row">
     <% @projects.each do |project| %>
     <div class="box col-lg-3">
-      <h4 class="project-title"> <%= link_to("#{project.title}", project_path(id: project.id))%></h4>
+      <h4 class="project-title"> <%= link_to("#{project.title}",
+        tenant_project_path(slug: project.tenant.slug, id: project.id))%></h4>
       <div class="thumbnail">
         <%= image_tag project.photos.first.image.url %>
       </div>
       <h5 class="project-desc"><%= project.description %></h5>
+      <%= form_for :pending_loan, url: pending_loan_path do |f| %>
+      <%= f.hidden_field :project_id, value: project.id %>
+      <%= f.hidden_field :loan_amount, value: 2500 %>
+      <%= f.submit "Lend $25", class: "btn btn-default" %>
+      <% end %>
     </div>
     <% end %>
   </div>

--- a/app/views/tenants/projects/index.html.erb
+++ b/app/views/tenants/projects/index.html.erb
@@ -16,8 +16,8 @@
         <% end %>
         <%= form_for :pending_loan, url: pending_loan_path do |f| %>
           <%= f.hidden_field :project_id, value: project.id %>
-          <%= f.hidden_field :loan_amount, value: project.price %>
-          <%= f.submit 'Lend', class: "btn btn-default" %>
+          <%= f.hidden_field :loan_amount, value: 2500 %>
+          <%= f.submit "Lend $25", class: "btn btn-default" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tenants/projects/show.html.erb
+++ b/app/views/tenants/projects/show.html.erb
@@ -5,12 +5,12 @@
 <% end %>
 
 <div id="history">
-  <table class='table table-bordered'>
+  <table class="table table-bordered">
     <thead>
       <tr>
         <th data-field="Price"> Price </th>
         <th data-field="Repayment Rate">Repayment Rate</th>
-        <th data-field='Requested By'>Requested By</th>
+        <th data-field="Requested By">Requested By</th>
         <th data-field="Repayment Begin"> Repayment begin</th>
       </tr>
     </thead>
@@ -34,8 +34,8 @@
   <% unless @project.retired %>
     <%= form_for :pending_loan, url: pending_loan_path do |f| %>
     <%= f.hidden_field :project_id, value: @project.id %>
-    <%= f.hidden_field :loan_amount, value: @project.price %>
-    <%= f.submit 'Lend', class: "btn btn-default" %>
+    <%= f.hidden_field :loan_amount, value: 2500 %>
+    <%= f.submit "Lend $25", class: "btn btn-default" %>
     <% end %>
   <% end %>
 </div>

--- a/test/integration/authenticated_lender_test.rb
+++ b/test/integration/authenticated_lender_test.rb
@@ -20,7 +20,7 @@ class AuthenticatedLenderTest < ActionDispatch::IntegrationTest
     visit "/#{project.tenant.slug}"
 
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     visit root_path
 

--- a/test/integration/guest_user_test.rb
+++ b/test/integration/guest_user_test.rb
@@ -36,7 +36,7 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     visit root_path
     click_link_or_button(project.categories.first.name)
 
-    assert_equal category_path(id: project.categories.first.id), current_path
+    assert_equal projects_path, current_path
     assert page.has_content?(project.title)
     assert page.has_content?(project.categories.first.name)
   end
@@ -45,8 +45,7 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     project1 = create(:project)
     project2 = create(:project)
 
-    visit root_path
-    click_link_or_button("#{project1.categories.first.name}")
+    visit projects_path
     click_link_or_button(project1.title)
 
     assert_equal tenant_project_path(
@@ -104,16 +103,16 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     tenant = create(:tenant)
     tenant.projects << create(:project, price: 8900)
 
-    visit root_path
-    click_link_or_button "#{tenant.projects.first.categories.first.name}"
-    within(".row") do
-      click_link_or_button("Lend")
+    visit projects_path
+    click_link_or_button "#{tenant.projects.first.title}"
+    within("#lend-form") do
+      click_link_or_button("Lend $25")
     end
 
     assert_equal "/pending_loan", current_path
     within("#pending_loans") do
       assert page.has_content?(tenant.projects.first.title)
-      assert page.has_content?("#{tenant.projects.first.price}")
+      assert page.has_content?("$25.00")
     end
   end
 
@@ -121,10 +120,10 @@ class GuestUserTest < ActionDispatch::IntegrationTest
   the pending_loans still retains the items" do
     user = create(:user)
     project = create(:project)
-    visit root_path
-    click_link_or_button("#{project.categories.first.name}")
-    within(".row") do
-      click_link_or_button("Lend")
+    visit projects_path
+    click_link_or_button(project.title)
+    within("#lend-form") do
+      click_link_or_button("Lend $25")
     end
     fill_in "session[username]", with: user.username
     fill_in "session[password]", with: user.password
@@ -138,10 +137,10 @@ class GuestUserTest < ActionDispatch::IntegrationTest
     assert page.has_content?("You have successfully completed your loans.")
     assert_equal user_order_path(user_id: user.id, id: user.orders.first.id),
                  current_path
-    assert page.has_content?(user.orders.first.total_cost / 100)
+    assert page.has_content?(user.orders.first.final_total / 100)
     assert page.has_content?(user.orders.first.status)
     assert page.has_content?(project.title)
-    assert page.has_content?(project.price / 100)
+    assert page.has_content?("25.00")
   end
 
   test "while on project show page for a specific tenant, I can click the

--- a/test/integration/lend_test.rb
+++ b/test/integration/lend_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class OrderIntegrationTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  test "authenticated lender can make a default loan of $25" do
+    user = create(:user)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+    tenant = create(:tenant)
+    tenant.projects << create(:project)
+
+    visit "/#{tenant.slug}"
+    within(".row") do
+      click_link_or_button("Lend $25")
+    end
+
+    within("#pending_loans") do
+      assert page.has_content?("$25.00")
+    end
+  end
+end

--- a/test/integration/order_integration_test.rb
+++ b/test/integration/order_integration_test.rb
@@ -15,10 +15,8 @@ class OrderIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "authed lender can see previous order on their Loans page" do
-    skip
-    user = create(:user)
-    create(:project)
     order = create(:order_with_loan)
+    user = order.user
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
     visit user_orders_path(user)
@@ -29,13 +27,8 @@ class OrderIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "authed lender on Loans page can see link to individual loans" do
-    skip
-    user = create(:user)
-    project = create(:project)
-    order = create(order)
-    project.orders << order
-    order.user_id = user.id
-    order.save
+    order = create(:order_with_loan)
+    user = order.user
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
     visit user_orders_path(user)
@@ -45,12 +38,8 @@ class OrderIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "authed lender can go to specific orders from order history" do
-    skip
-    user = create(:user)
-    project = create(:project)
-    order = project.orders.create(total_cost: 1000,
-                                  user_id: user.id,
-                                  status: "Completed")
+    order = create(:order_with_loan)
+    user = order.user
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
     visit user_orders_path(user)
@@ -59,5 +48,20 @@ class OrderIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     assert user_order_path(user, order), current_path
+  end
+
+  test "an authed lender can see loan details on each order page" do
+    order = create(:order_with_loan)
+    user = order.user
+    order.loans << create(:loan, amount: 3500)
+    loan1 = order.loans.first
+    loan2 = order.loans.second
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit user_order_path(user, order)
+    assert page.has_content?(order.total_cost / 100)
+    assert page.has_content?(loan1.amount / 100)
+    assert page.has_content?(loan1.project.tenant.location)
+    assert page.has_content?(loan2.amount / 100)
   end
 end

--- a/test/integration/pending_loans_integration_test.rb
+++ b/test/integration/pending_loans_integration_test.rb
@@ -10,7 +10,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     visit "/#{tenant.slug}"
 
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
 
     within("#flash_notice") do
@@ -24,7 +24,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
 
     within("#pending_loans") do
@@ -40,7 +40,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/"
     click_link_or_button(project.categories.first.name)
-    first(".row").click_button("Lend")
+    first(".row").click_button("Lend $25")
 
     within("#pending_loans") do
       click_link_or_button("Delete")
@@ -58,7 +58,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{project.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button("Delete")
 
@@ -77,18 +77,17 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{project1.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     visit "/#{project2.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
 
     within("#pending_loans") do
       assert page.has_content?(project1.title)
-      assert page.has_content?(project1.price)
+      assert page.has_content?("$25.00")
       assert page.has_content?(project2.title)
-      assert page.has_content?(project2.price)
     end
   end
 
@@ -97,7 +96,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     visit "/#{project.tenant.slug}"
 
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button("Checkout")
 
@@ -111,11 +110,11 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{project1.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     visit "/#{project2.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button("Empty Cart")
 
@@ -132,7 +131,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{project.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button(project.title)
 
@@ -149,13 +148,13 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
 
     assert_equal "/pending_loan", current_path
     within("#pending_loans") do
       assert page.has_content?(tenant.projects.first.title)
-      assert page.has_content?(tenant.projects.first.price)
+      assert page.has_content?("$25.00")
     end
   end
 
@@ -169,7 +168,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
 
     assert_equal "/pending_loan", current_path
@@ -179,7 +178,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     within("#pending_loans") do
       assert page.has_content?(tenant.organization)
       assert page.has_content?(tenant.projects.first.title)
-      assert page.has_content?(tenant.projects.first.price)
+      assert page.has_content?("$25.00")
     end
   end
 
@@ -190,7 +189,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{project.tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     fill_in "session[username]", with: user.username
     fill_in "session[password]", with: user.password
@@ -213,7 +212,7 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
 
     visit "/#{tenant.slug}"
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button("Delete")
 

--- a/test/integration/tenant_project_view_test.rb
+++ b/test/integration/tenant_project_view_test.rb
@@ -40,7 +40,7 @@ class TenantProjectViewTest < ActionDispatch::IntegrationTest
 
     visit tenant_project_path(slug: project.tenant.slug, id: project.id)
 
-    assert page.has_button?("Lend")
+    assert page.has_button?("Lend $25")
   end
 
   test "a user can go back to the projects page from the tenant project page" do
@@ -60,12 +60,12 @@ class TenantProjectViewTest < ActionDispatch::IntegrationTest
 
     visit tenant_project_path(slug: tenant_slug, id: project.id)
     within("#lend-form") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
 
     within("#pending_loans") do
       assert page.has_content?(project.title)
-      assert page.has_content?(project.price)
+      assert page.has_content?("$25.00")
     end
   end
 end

--- a/test/integration/user_login_test.rb
+++ b/test/integration/user_login_test.rb
@@ -81,9 +81,9 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     project = create(:project, title: "A Water Purifier")
 
-    visit category_path(project.categories.first.id)
+    visit projects_path
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     log_in_user(user)
 
@@ -96,9 +96,9 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     project = create(:project, title: "A Water Purifier")
 
-    visit category_path(project.categories.first.id)
+    visit projects_path
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     log_in_user(user)
 
@@ -112,9 +112,9 @@ class UserLoginTest < ActionDispatch::IntegrationTest
     user = create(:user)
     project = create(:project, title: "A Water Purifier")
 
-    visit category_path(project.categories.first.id)
+    visit projects_path
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button("Checkout")
     log_in_user(user)
@@ -128,9 +128,9 @@ class UserLoginTest < ActionDispatch::IntegrationTest
   gets redirected back to the pending_loan_show page" do
     project = create(:project, title: "A Water Purifier")
 
-    visit category_path(project.categories.first.id)
+    visit projects_path
     within(".row") do
-      click_link_or_button("Lend")
+      click_link_or_button("Lend $25")
     end
     click_link_or_button("Checkout")
     fill_in "signup[username]",               with: "Jwan622"

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -10,7 +10,6 @@ class OrderTest < ActiveSupport::TestCase
     assert_equal user.id, order.user_id
   end
 
-
   test "an order is not valid without all attributes" do
     order1 = build(:order, total_cost: nil)
     order2 = build(:order, user_id: nil)
@@ -37,5 +36,28 @@ class OrderTest < ActiveSupport::TestCase
     3.times { order.loans << create(:loan, amount: 1500) }
 
     assert_equal 4500, order.total_cost
+  end
+
+  test "an order's total cost is updated when add'l loans are added" do
+    order = create(:order)
+    3.times { order.loans << create(:loan, amount: 1500) }
+    initial_total = order.total_cost
+
+    order.loans << create(:loan, amount: 2000)
+
+    assert_equal initial_total + 2000, order.total_cost
+  end
+
+  test "orders can be selected by status" do
+    4.times { create(:order, status: "cancelled") }
+    3.times { create(:order, status: "completed") }
+    8.times { create(:order, status: "paid") }
+    5.times { create(:order, status: "ordered") }
+
+    assert_equal 4, Order.cancelled.count
+    assert_equal 3, Order.complete.count
+    assert_equal 8, Order.paid.count
+    assert_equal 5, Order.ordered.count
+    assert_equal 20, Order.count
   end
 end


### PR DESCRIPTION
By default, a user will click the lend $25 by clicking the "Lend $25" button that appears below each project. This small change required a lot of changes to the tests and views. I'll open another PR to address the ability to modify the amount once the loan is in the cart(pending loans).

Changes include:
* Changing buttons from Lend to Lend $25
* Changing the links from root_path to lead to projects_path in preparation for the filtering
* Changing the links from the projects_path to lead to tenants_project_path(slug: project.slug)
* Adding new model/order tests and integration/lend tests

