### PR TITLE
Platform project edit closes #187

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ group :development, :test do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console',            '~> 2.0'
 
+  # Better errors gem
+  gem 'better_errors'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring',                 '~> 1.2.0'
   gem 'capybara',               '~> 2.4.4'

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :development, :test do
   gem 'web-console',            '~> 2.0'
 
   # Better errors gem
-  gem 'better_errors'
+  gem 'better_errors',          '~> 2.1.1'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring',                 '~> 1.2.0'
   gem 'capybara',               '~> 2.4.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
-  better_errors
+  better_errors (~> 2.1.1)
   bootstrap_form (~> 2.2.0)
   byebug (~> 3.5.1)
   cancancan (~> 1.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,10 @@ GEM
     addressable (2.3.6)
     arel (6.0.0)
     bcrypt (3.1.9)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap_form (2.2.0)
@@ -231,6 +235,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
+  better_errors
   bootstrap_form (~> 2.2.0)
   byebug (~> 3.5.1)
   cancancan (~> 1.10)

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ProjectsController < Admin::BaseController
   def index
     @project = Project.new
-    @projects = Project.all
+    @projects = Project.all.order(id: :asc)
   end
 end

--- a/app/controllers/tenants/projects_controller.rb
+++ b/app/controllers/tenants/projects_controller.rb
@@ -26,10 +26,20 @@ class Tenants::ProjectsController < ApplicationController
     @project = Project.find(params[:id])
     if @project.update_attributes(new_params)
       flash[:notice] = "#{@project.title} Updated"
+      if session[:admin]
+        redirect_to admin_projects_path
+      else
+        redirect_to tenant_dashboard_path
+      end
     else
-      flash[:errors] = "Invalid Attributes"
+      if new_params[:categories].empty?
+        flash[:errors] = "Please select one or more categories"
+        redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
+      else
+        flash[:errors] = "Invalid Attributes"
+        redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
+      end
     end
-    redirect_to tenant_dashboard_path
   end
 
   def new
@@ -64,7 +74,7 @@ class Tenants::ProjectsController < ApplicationController
   def new_params
     new_param = project_params
     new_param[:categories] = new_categories
-    new_param[:tenant_id] = current_user.tenant.id
+    new_param[:tenant_id] = @project.tenant.id
     new_param
   end
 end

--- a/app/controllers/tenants/projects_controller.rb
+++ b/app/controllers/tenants/projects_controller.rb
@@ -74,7 +74,11 @@ class Tenants::ProjectsController < ApplicationController
   def new_params
     new_param = project_params
     new_param[:categories] = new_categories
-    new_param[:tenant_id] = @project.tenant.id
+    if current_user.nil?
+      new_param[:tenant_id] = @project.tenant.id
+    else
+      new_param[:tenant_id] = current_user.tenant_id
+    end
     new_param
   end
 end

--- a/app/controllers/tenants/projects_controller.rb
+++ b/app/controllers/tenants/projects_controller.rb
@@ -34,11 +34,10 @@ class Tenants::ProjectsController < ApplicationController
     else
       if new_params[:categories].empty?
         flash[:errors] = "Please select one or more categories"
-        redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
       else
         flash[:errors] = "Invalid Attributes"
-        redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
       end
+        redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
     end
   end
 

--- a/app/controllers/tenants/projects_controller.rb
+++ b/app/controllers/tenants/projects_controller.rb
@@ -37,7 +37,7 @@ class Tenants::ProjectsController < ApplicationController
       else
         flash[:errors] = "Invalid Attributes"
       end
-        redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
+      redirect_to edit_tenant_project_path(@project, slug: @project.tenant.id)
     end
   end
 

--- a/app/views/admin/projects/edit.html.erb
+++ b/app/views/admin/projects/edit.html.erb
@@ -1,6 +1,0 @@
-
-<div id="edit">
-  <h3>Edit Project</h3>
-</div>
-
-<%= render partial: 'shared/edit_project_form', locals: {project: Project.new} %>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -1,36 +1,17 @@
 <div id="projects_header">
   <h1> Projects </h1>
 </div>
-
-<div class="row">
-  <div class="col-lg-8 col-lg-offset-2">
-    <div class="project">
-      <h4 class="form-title"> Create New Project </h4>
-        <%= bootstrap_form_for(@project, style: :inline, url: projects_path, html: {multipart: true}) do |f| %>
-          <%= f.text_field :title %>
-          <%= f.text_field :price %>
-          <%= f.text_field :description %>
-          <%= f.label :image, 'Attach an Image' %><br />
-          <%= f.file_field :image %>
-          <%= f.collection_select(:categories, Category.all, :id, :name, {}, {:multiple => true}) %>
-          <%= f.submit "Create Project" %>
-        <% end %>
-    </div>
-  </div>
-</div>
-
 <div id="all_projects">
   <h2>All Projects</h2>
   <table style="width:95%">
     <tr>
       <th>Title</th>
       <th>Description</th>
-      <th>Edit</th>
     </tr>
 
     <% @projects.each do |project| %>
       <tr>
-        <td><%= project.title %></td>
+        <td><%= link_to project.title, edit_tenant_project_path(project, slug: project.tenant.id) %></td>
         <td><%= project.description %></td>
       </tr>
     <% end %>

--- a/test/integration/admin_projects_test.rb
+++ b/test/integration/admin_projects_test.rb
@@ -32,4 +32,28 @@ class AdminProjectsTest < ActionDispatch::IntegrationTest
 
     assert page.has_content?(project.title)
   end
+
+  test "an admin in the projects dashboard has a link to the edit project
+  page" do
+    admin = create(:admin)
+    project = create(:project)
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit admin_projects_path
+
+    assert page.has_link?(project.title)
+  end
+
+  test "an admin can click on a project in the dashboard and goes to the edit
+  project page" do
+    admin = create(:admin)
+    project = create(:project, tenant_id: 1)
+    tenant = create(:tenant, id: 1)
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit admin_projects_path
+    click_link_or_button(project.title)
+
+    assert edit_tenant_project_path(project, slug: tenant.slug)
+  end
 end


### PR DESCRIPTION
* Added better_errors gem so we have better errors when we have errors. 
* Modified Projects controller to always display projects in order by ID.
* For some reason, tenant/projects controller was losing @current_user, so I used the admin flag stored in the session to redirect appropriately once edits were made.
* Fixed errors in new_params method because since an admin wasn't a tenant, it couldn't get the appropriate ID. Changed code to get the tenant id from the project.
* Took create project functionality out of the projects dashboard. Admin can use tenant tools to do so.
* Wrote tests.