### PR TITLE
Allow user to update loan amounts in cart; closes #163

### DIFF
--- a/app/controllers/pending_loans_controller.rb
+++ b/app/controllers/pending_loans_controller.rb
@@ -17,12 +17,9 @@ class PendingLoansController < ApplicationController
   end
 
   def update
-    if params[:pending_loan].nil?
-      delete_all_projects_from_cart
-    else
-      delete_specific_project_from_cart
-      flash[:notice] = "Project removed from cart"
-    end
+    session[:pending_loan][params[:pending_loan][:project_id]] =
+    params[:pending_loan][:loan_dollar_amount].to_f * 100
+    flash[:notice] = "Project loan amount updated"
     redirect_to pending_loan_path
   end
 
@@ -32,10 +29,13 @@ class PendingLoansController < ApplicationController
     redirect_to pending_loan_path
   end
 
-  def update_project_amount
-    session[:pending_loan][params[:update_pending_loan_amount][:project_id]] =
-       params[:update_pending_loan_amount][:loan_amount]
-    flash[:notice] = "Project loan amount updated"
+  def delete_one
+    if params[:pending_loan].nil?
+      delete_all_projects_from_cart
+    else
+      delete_specific_project_from_cart
+      flash[:notice] = "Project removed from cart"
+    end
     redirect_to pending_loan_path
   end
 
@@ -66,11 +66,6 @@ class PendingLoansController < ApplicationController
   end
 
   def loan_is_already_pending
-    session[:pending_loan][pending_loan_params[:project_id]]
-  end
-
-  def update_specific_loan
-    session[:pending_loan][pending_loan_params[:project_id]] =
     session[:pending_loan][pending_loan_params[:project_id]]
   end
 

--- a/app/controllers/pending_loans_controller.rb
+++ b/app/controllers/pending_loans_controller.rb
@@ -7,22 +7,21 @@ class PendingLoansController < ApplicationController
 
   def show
     @pending_loans = {}
-    if pending_loans_exist?
+    if session[:pending_loan].present?
       session[:pending_loan].each do |project_id, loan_amount|
         @pending_loans[Project.find(project_id.to_i)] = loan_amount
       end
-    else
-      @pending_loans
     end
   end
 
   def update
-    if valid_loan_amount
-      session[:pending_loan][params[:pending_loan][:project_id]] =
-      params[:pending_loan][:loan_dollar_amount].to_f * 100
+    if valid_loan_amount(pending_project_amount)
+      session[:pending_loan][pending_loan_params[:project_id]] =
+        pending_loan_params[:loan_dollar_amount].to_f * 100
       flash[:notice] = "Project loan amount updated"
     else
-      flash[:notice] = "Please enter a valid amount between $10 & $500"
+      flash[:notice] = "Please enter a valid amount between $10
+                        & $#{pending_project_amount / 100}"
     end
     redirect_to pending_loan_path
   end
@@ -34,19 +33,21 @@ class PendingLoansController < ApplicationController
   end
 
   def delete_one
-    if params[:pending_loan].nil?
-      delete_all_projects_from_cart
-    else
-      delete_specific_project_from_cart
-      flash[:notice] = "Project removed from cart"
-    end
+    delete_project_from_cart
+    flash[:notice] = "Project removed from cart"
     redirect_to pending_loan_path
   end
 
   private
 
   def pending_loan_params
-    params.require(:pending_loan).permit(:project_id, :loan_amount)
+    params.require(:pending_loan).permit(:project_id,
+                                         :loan_amount,
+                                         :loan_dollar_amount)
+  end
+
+  def pending_project_amount
+    Project.find(pending_loan_params[:project_id]).current_amount_needed
   end
 
   def update_cart
@@ -54,39 +55,22 @@ class PendingLoansController < ApplicationController
       update_existing_cart
     else
       session[:pending_loan] = {
-        pending_loan_params[:project_id] =>
-          pending_loan_params[:loan_amount]
+        pending_loan_params[:project_id] => pending_loan_params[:loan_amount]
       }
     end
   end
 
   def update_existing_cart
-    if loan_is_already_pending
-      update_specific_loan
-    else
-      session[:pending_loan][pending_loan_params[:project_id]] =
+    session[:pending_loan][pending_loan_params[:project_id]] =
       pending_loan_params[:loan_amount].to_s
-    end
   end
 
-  def loan_is_already_pending
-    session[:pending_loan][pending_loan_params[:project_id]]
-  end
-
-  def pending_loans_exist?
-    session[:pending_loan] != nil
-  end
-
-  def delete_all_projects_from_cart
-    session.delete(:pending_cart)
-  end
-
-  def delete_specific_project_from_cart
+  def delete_project_from_cart
     session[:pending_loan].delete(pending_loan_params[:project_id])
   end
 
-  def valid_loan_amount
-    amount = params[:pending_loan][:loan_dollar_amount].to_f
-    amount > 10 && amount < 500
+  def valid_loan_amount(max_amount)
+    amount = pending_loan_params[:loan_dollar_amount].to_f
+    amount > 10 && amount <= max_amount / 100.00
   end
 end

--- a/app/controllers/pending_loans_controller.rb
+++ b/app/controllers/pending_loans_controller.rb
@@ -17,9 +17,13 @@ class PendingLoansController < ApplicationController
   end
 
   def update
-    session[:pending_loan][params[:pending_loan][:project_id]] =
-    params[:pending_loan][:loan_dollar_amount].to_f * 100
-    flash[:notice] = "Project loan amount updated"
+    if valid_loan_amount
+      session[:pending_loan][params[:pending_loan][:project_id]] =
+      params[:pending_loan][:loan_dollar_amount].to_f * 100
+      flash[:notice] = "Project loan amount updated"
+    else
+      flash[:notice] = "Please enter a valid amount between $10 & $500"
+    end
     redirect_to pending_loan_path
   end
 
@@ -79,5 +83,10 @@ class PendingLoansController < ApplicationController
 
   def delete_specific_project_from_cart
     session[:pending_loan].delete(pending_loan_params[:project_id])
+  end
+
+  def valid_loan_amount
+    amount = params[:pending_loan][:loan_dollar_amount].to_f
+    amount > 10 && amount < 500
   end
 end

--- a/app/models/pending_loan.rb
+++ b/app/models/pending_loan.rb
@@ -1,4 +1,6 @@
 class PendingLoan
+  include ActionView::Helpers::NumberHelper
+
   def initialize(pending_loan)
     @pending_loan = pending_loan
   end
@@ -19,6 +21,10 @@ class PendingLoan
     @pending_loan.values.inject(0) do |sum, loan_amount|
       sum + loan_amount.to_i
     end
+  end
+
+  def formatted_pending_total
+    number_to_currency(pending_total / 100)
   end
 
   def checkout!(user_id)

--- a/app/models/pending_loan.rb
+++ b/app/models/pending_loan.rb
@@ -24,7 +24,7 @@ class PendingLoan
   end
 
   def formatted_pending_total
-    number_to_currency(pending_total / 100)
+    number_to_currency(pending_total / 100.00)
   end
 
   def checkout!(user_id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,6 +30,14 @@ class Project < ActiveRecord::Base
     number_to_currency(price / 100.00)
   end
 
+  def current_amount_needed
+    if loans.present?
+      price - loans.map(&:amount).reduce(:+)
+    else
+      price
+    end
+  end
+
   private
 
   def add_default_repayment_rate

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -15,7 +15,7 @@
       <tr>
       <tr>
         <td><%= link_to("Order #{order.id}", user_order_path(@user, order)) %></td>
-        <td><%= number_to_currency order.total_cost/100 %></td>
+        <td><%= number_to_currency order.total_cost/100.00 %></td>
         <td><%= order.status %></td>
         <td><%= order.updated_at.strftime("%b %d, %Y, %I:%M") %></td>
         <td><%= order.created_at.strftime("%b %d, %Y, %I:%M") %></td>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -18,9 +18,9 @@
       <tr>
         <td><%= link_to loan.project.title, project_path(loan.project) %></td>
         <td><%= loan.project.tenant.location %></td>
-        <td><%= number_to_currency loan.amount / 100 %></td>
+        <td><%= number_to_currency loan.amount / 100.00 %></td>
       </tr>
     <% end %>
-    <tr><h2>Order Total: <%= number_to_currency @order.final_total / 100 %></h2><tr>
+    <tr><h2>Order Total: <%= number_to_currency @order.final_total / 100.00 %></h2><tr>
   </table>
 </div>

--- a/app/views/pending_loans/show.html.erb
+++ b/app/views/pending_loans/show.html.erb
@@ -4,9 +4,9 @@
   <table class="table table-bordered">
     <thead>
       <tr class="warning">
-        <th data-field="Organization Name">Organization Name</th>
-        <th data-field="Purpose">Purpose</th>
-        <th data-field="Amount">Amount</th>
+        <th data-field="organization-name">Organization</th>
+        <th data-field="project-title">Project</th>
+        <th data-field="loan-amount">Amount</th>
         <th></th>
       </tr>
     </thead>
@@ -17,7 +17,7 @@
         <tr id=<%= "project_#{project.id}" %>>
           <td><%= project.tenant.organization %></td>
           <td><%= link_to project.title, tenant_project_path(slug: project.tenant.slug, id: project.id) %></td>
-          <td id=<%= "quantity_#{project.id}" %>><%= number_to_currency loan_amount.to_i / 100 %></td>
+          <td id=<%= "amount_#{project.id}" %>><%= number_to_currency loan_amount.to_i / 100 %></td>
           <td>
             <%= form_for :pending_loan, url: pending_loan_path do |f| %>
               <input name="_method" type="hidden" value="patch" />
@@ -27,6 +27,7 @@
           </td>
         </tr>
       <% end %>
+      <h3>Order total: <%= pending_loans.formatted_pending_total %><h3>
     <% end %>
   </table>
 

--- a/app/views/pending_loans/show.html.erb
+++ b/app/views/pending_loans/show.html.erb
@@ -6,7 +6,8 @@
       <tr class="warning">
         <th data-field="organization-name">Organization</th>
         <th data-field="project-title">Project</th>
-        <th data-field="loan-amount">Amount</th>
+        <th data-field="funds-needed">Funds needed</th>
+        <th data-field="loan-amount">Your loan</th>
         <th></th>
       </tr>
     </thead>
@@ -17,6 +18,7 @@
         <tr id=<%= "project_#{project.id}" %>>
           <td><%= project.tenant.organization %></td>
           <td><%= link_to project.title, tenant_project_path(slug: project.tenant.slug, id: project.id) %></td>
+          <td id=<%= "funds_needed_#{project.id}" %>><%= number_to_currency project.current_amount_needed / 100.00 %></td>
           <td id=<%= "amount_#{project.id}" %>><%= number_to_currency loan_amount.to_i / 100.00 %></td>
           <td>
             <%= form_for :pending_loan, url: update_loan_amount_path do |f| %>
@@ -36,19 +38,20 @@
         </tr>
       <% end %>
       <h3>Order total: <%= pending_loans.formatted_pending_total %><h3>
+      <% if current_user %>
+        <%= form_for :cart, url: user_orders_path(user_id: current_user.id) do |f| %>
+          <%= f.submit "Checkout", class: "btn btn-default" %>
+        <% end %>
+      <% else %>
+        <%= link_to "Checkout", new_user_path(message: "You Must Signup or Login to Lend Money"), class: "btn btn-default" %>
+      <% end %>
+
+      <%= form_for :cart, url: pending_loan_path do |f| %>
+        <input name="_method" type="hidden" value="delete" />
+        <%= f.submit "Empty Cart", class: "btn btn-default" %>
+      <% end %>
     <% end %>
   </table>
 
-  <% if current_user %>
-    <%= form_for :cart, url: user_orders_path(user_id: current_user.id) do |f| %>
-      <%= f.submit "Checkout", class: "btn btn-default" %>
-    <% end %>
-  <% else %>
-    <%= link_to "Checkout", new_user_path(message: "You Must Signup or Login to Lend Money"), class: "btn btn-default" %>
-  <% end %>
 
-  <%= form_for :cart, url: pending_loan_path do |f| %>
-    <input name="_method" type="hidden" value="delete" />
-    <%= f.submit "Empty Cart", class: "btn btn-default" %>
-  <% end %>
 </div>

--- a/app/views/pending_loans/show.html.erb
+++ b/app/views/pending_loans/show.html.erb
@@ -17,10 +17,18 @@
         <tr id=<%= "project_#{project.id}" %>>
           <td><%= project.tenant.organization %></td>
           <td><%= link_to project.title, tenant_project_path(slug: project.tenant.slug, id: project.id) %></td>
-          <td id=<%= "amount_#{project.id}" %>><%= number_to_currency loan_amount.to_i / 100 %></td>
+          <td id=<%= "amount_#{project.id}" %>><%= number_to_currency loan_amount.to_i / 100.00 %></td>
           <td>
-            <%= form_for :pending_loan, url: pending_loan_path do |f| %>
-              <input name="_method" type="hidden" value="patch" />
+            <%= form_for :pending_loan, url: update_loan_amount_path do |f| %>
+              <input name="_method" type="hidden" />
+              <%= f.text_field :loan_dollar_amount, class: 'form-control' %>
+              <%= f.hidden_field :project_id, :value => project.id %>
+              <%= f.submit "Change amount", class: "btn btn-default" %>
+            <% end %>
+          </td>
+          <td>
+            <%= form_for :pending_loan, url: delete_pending_loan_path do |f| %>
+              <input name="_method" type="hidden" value="delete_one" />
               <%= f.hidden_field :project_id, :value => project.id %>
               <%= f.submit "Delete", class: "btn btn-default btn-delete-cart-project" %>
             <% end %>

--- a/app/views/shared/_status_table.html.erb
+++ b/app/views/shared/_status_table.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= link_to("#{order.user.first_name}'s Order #{order.id}", user_order_path(order.user, order)) %></td>
-  <td><%= number_to_currency order.total_cost/100 %></td>
+  <td><%= number_to_currency order.total_cost/100.00 %></td>
   <td><%= order.status %></td>
   <td><%= order.created_at.strftime("%b %d, %Y") %></td>
   <td>

--- a/app/views/tenants/projects/show.html.erb
+++ b/app/views/tenants/projects/show.html.erb
@@ -15,7 +15,7 @@
       </tr>
     </thead>
       <tr>
-        <td> <%= number_to_currency @project.price / 100 %></td>
+        <td> <%= number_to_currency @project.price / 100.00 %></td>
         <td> <%= @project.repayment_rate %></td>
         <td> <%= @project.requested_by %></td>
         <td> <%= @project.repayment_begin %></td>
@@ -25,7 +25,7 @@
 
 <h2><%= "RETIRED ITEM" if @project.retired %></h2>
 <div id="description"><%= @project.description %></div>
-<div id="price"><%= number_to_currency @project.price / 100 %></div>
+<div id="price"><%= number_to_currency @project.price / 100.00 %></div>
 <div id="repayment-rate">Repayment Rate: <%= @project.repayment_rate %></div>
 <div id="requested-by">Requested by: <%= @project.requested_by %></div>
 <div id="repayment-begin">Repayment begins: <%= @project.repayment_begin %> </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
   get "/choose", to: "static_pages#choose"
 
   resource :pending_loan, except: [:index, :edit]
-  post :delete_pending_loan, to: 'pending_loans#delete_one'
-  post :update_loan_amount, to: 'pending_loans#update'
+  post :delete_pending_loan, to: "pending_loans#delete_one"
+  post :update_loan_amount, to: "pending_loans#update"
 
   namespace :admin do
     get "/dashboard", to: "base#dashboard"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get "/choose", to: "static_pages#choose"
 
   resource :pending_loan, except: [:index, :edit]
+  post :delete_pending_loan, to: 'pending_loans#delete_one'
+  post :update_loan_amount, to: 'pending_loans#update'
 
   namespace :admin do
     get "/dashboard", to: "base#dashboard"

--- a/test/integration/pending_loans_integration_test.rb
+++ b/test/integration/pending_loans_integration_test.rb
@@ -105,10 +105,11 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     project = create(:project)
     visit projects_path
     first(".row").click_button("Lend $25")
-    click_link_or_button("Checkout")
 
-
-
+    click_link_or_button("Change amount")
+    fill_in "pending_loan[loan_dollar_amount]", with: 35
+    click_link_or_button("Change amount")
+    assert page.has_content?("Order total: $35.00")
   end
 
   test "an unauthorized user cannot checkout until logged in" do

--- a/test/integration/pending_loans_integration_test.rb
+++ b/test/integration/pending_loans_integration_test.rb
@@ -112,6 +112,19 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Order total: $35.00")
   end
 
+  test "a user will be alerted when the loan amount is not valid" do
+    project = create(:project)
+    visit projects_path
+    first(".row").click_button("Lend $25")
+
+    click_link_or_button("Change amount")
+    fill_in "pending_loan[loan_dollar_amount]", with: -35
+    click_link_or_button("Change amount")
+    assert page.has_content?("Order total: $25.00")
+    assert page.has_content?("Please enter a valid amount between $10 & $500")
+  end
+
+
   test "an unauthorized user cannot checkout until logged in" do
     project = create(:project)
     visit "/#{project.tenant.slug}"

--- a/test/integration/pending_loans_integration_test.rb
+++ b/test/integration/pending_loans_integration_test.rb
@@ -91,6 +91,26 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "a user can see the pending total cost of their cart" do
+    3.times do
+      project = create(:project)
+      visit "/#{project.tenant.slug}"
+      click_link_or_button("Lend $25")
+    end
+
+    assert page.has_content?("Order total: $75.00")
+  end
+
+  test "a user can change the loan amount for a project in their cart" do
+    project = create(:project)
+    visit projects_path
+    first(".row").click_button("Lend $25")
+    click_link_or_button("Checkout")
+
+
+
+  end
+
   test "an unauthorized user cannot checkout until logged in" do
     project = create(:project)
     visit "/#{project.tenant.slug}"
@@ -183,7 +203,6 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "a user can checkout once logged in" do
-    skip
     project = create(:project)
     user = create(:user)
 
@@ -194,12 +213,11 @@ class PendingLoansIntegrationTest < ActionDispatch::IntegrationTest
     fill_in "session[username]", with: user.username
     fill_in "session[password]", with: user.password
     click_link_or_button("Login")
-    click_link_or_button("Cart")
     click_link_or_button("Checkout")
 
-    assert_equal user_order_path(user_id: user.id,
-                                 id: user.orders.first.id), current_path
-    assert page.has_content?(project.price)
+    assert_equal user_order_path(user_id: user.id, id: user.orders.first.id),
+                 current_path
+    assert page.has_content?("$25.00")
     assert page.has_content?(project.title)
   end
 


### PR DESCRIPTION
This adds functionality and tests to ensure that users can modify the loan amount for each project in their cart.

Changes include:
* Updating flash messages to notify of acceptable loan amount values
* Add the amount needed for each project to the pending loan views, so the user knows how much close the project is to completion.
* Removed unneeded methods in pending loans controller.
* Add pending order total to pending_loans view