### PR TITLE
fixed email validator callback and other stuff #closes 194

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   has_secure_password
 
+  before_save :valid_email?
+
   belongs_to :tenant
   has_many :orders
 
@@ -15,7 +17,7 @@ class User < ActiveRecord::Base
   validates :zipcode, presence: true
   validates :country, presence: true
 
-  def valid_email?(email)
+  def valid_email?
     email_checker(email)
   end
 


### PR DESCRIPTION
-fixed callback for email validator. apparently no callbacks accept arguments because any argument you pass in is probably a column in the database and you have access to those columns via implied getter and setter methods.
-fixing category index page
-fix links in nav bar. "Lend" goes to projects_index_path and "Keevahh" goes to root_path.