### PR TITLE
Fixes issue that was preventing an admin from editing a project on heroku closes #187

### DIFF
--- a/app/controllers/tenants/projects_controller.rb
+++ b/app/controllers/tenants/projects_controller.rb
@@ -76,7 +76,11 @@ class Tenants::ProjectsController < ApplicationController
     if current_user.nil?
       new_param[:tenant_id] = @project.tenant.id
     else
-      new_param[:tenant_id] = current_user.tenant_id
+      if current_user.admin?
+        new_param[:tenant_id] = @project.tenant.id
+      else
+        new_param[:tenant_id] = current_user.tenant_id
+      end
     end
     new_param
   end


### PR DESCRIPTION
This addresses an issue with the code that was causing our platform admin not to be able to edit projects on Heroku.

This is a test case that works locally. I don't understand why, but at this point, Current_user is sometimes nil and sometimes not. I've added a conditional statement which will allow for any possibilities when it comes to the current user and updating the projects.